### PR TITLE
Minor improvemnts.

### DIFF
--- a/BusyIndicator/BusyIndicator.csproj
+++ b/BusyIndicator/BusyIndicator.csproj
@@ -8,7 +8,7 @@
 	<Company>Mohsen Golshani</Company>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
-    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIcon>Icon.ico</PackageIcon>
     <RepositoryUrl>https://github.com/Peoky/BusyIndicator</RepositoryUrl>
     <PackageTags>BusyIndicator Loader Spinner LoadingIndicator</PackageTags>
     <PackageReleaseNotes>New indicator types</PackageReleaseNotes>
@@ -18,7 +18,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="..\..\Assets\Icon.png">
+    <None Include="Icon.ico">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>

--- a/BusyIndicator/Properties/AssemblyInfo.cs
+++ b/BusyIndicator/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Windows.Markup;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -13,7 +13,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2021")]
 [assembly: AssemblyTrademark("BusyIndicator")]
 [assembly: AssemblyCulture("")]
-
+[assembly: XmlnsPrefix("https://github.com/Peoky/BusyIndicator", "busyIndicator")]
+[assembly: XmlnsDefinition("https://github.com/Peoky/BusyIndicator", "BusyIndicator")]
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/BusyIndicator/Theme/Default.xaml
+++ b/BusyIndicator/Theme/Default.xaml
@@ -1,0 +1,10 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/BusyMask/BusyMask.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Indicator/Indicator.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/Demo/MainWindow.xaml
+++ b/Demo/MainWindow.xaml
@@ -12,12 +12,13 @@
     mc:Ignorable="d">
 
     <Window.Resources>
-        <ResourceDictionary>
+        <ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Theme/Default.xaml" />
+        <!--<ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/BusyMask/BusyMask.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Indicator/Indicator.xaml" />
             </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary>
+        </ResourceDictionary>-->
     </Window.Resources>
 
     <busyIndicator:BusyMask

--- a/Demo/MainWindow.xaml
+++ b/Demo/MainWindow.xaml
@@ -2,7 +2,7 @@
     x:Class="Demo.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:busyIndicator="clr-namespace:BusyIndicator;assembly=BusyIndicator"
+    xmlns:busyIndicator="https://github.com/Peoky/BusyIndicator"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Title="MainWindow"

--- a/README.md
+++ b/README.md
@@ -18,29 +18,21 @@ BusyIndicator for WPF with multiple indicator types.
 <pre>Install-Package BusyIndicator</pre>  
 
 2. Add resources to App.xaml  
-<pre><code>&lt;ResourceDictionary&gt;
-            &lt;ResourceDictionary.MergedDictionaries&gt;
-                &lt;ResourceDictionary&gt;
-                    &lt;ResourceDictionary.MergedDictionaries&gt;
-                        &lt;ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/BusyMask/BusyMask.xaml"/&gt;
-                        &lt;ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Indicator/Indicator.xaml"/&gt;
-                    &lt;/ResourceDictionary.MergedDictionaries&gt;
-                &lt;/ResourceDictionary&gt;
-            &lt;/ResourceDictionary.MergedDictionaries&gt;
-&lt;/ResourceDictionary&gt;
+<pre><code>
+&lt;ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Theme/Default.xaml" />
 </code></pre>  
 
 3. Add a reference to the library in your view  
-<pre>xmlns:busyindicator="clr-namespace:BusyIndicator;assembly=BusyIndicator"</pre>  
+<pre>xmlns:busyIndicator="https://github.com/Peoky/BusyIndicator"</pre>  
 
 4. Create a BusyMask on top of main view  
-<pre><code>&lt;busyindicator:BusyMask x:Name="BusyIndicator" IsBusy="False" IndicatorType="Dashes" BusyContent="Please wait..." &gt;  
+<pre><code>&lt;busyIndicator:BusyMask x:Name="BusyIndicator" IsBusy="False" IndicatorType="Dashes" BusyContent="Please wait..." &gt;  
          
          
           <... main view goes here ... >
          
          
-&lt;/busyindicator:BusyMask&gt;</code></pre>  
+&lt;/busyIndicator:BusyMask&gt;</code></pre>  
 
 5. Set `IsBusy` property value to `true` or `false` to enable or disable the mask (or bind it)[check demo for a working example]
 <pre>BusyIndicator.IsBusy = true; or BusyIndicator.IsBusy = false; </pre>  


### PR DESCRIPTION
Summary of the changes,

- [x]  Add XAML prefix to the library as busyIndicator.
- [x] Change namespace call from `"clr-namespace:BusyIndicator;assembly=BusyIndicator"` to the repo url `"https://github.com/Peoky/BusyIndicator"`.
- [x] Merge the two resource dictionaries imports into one file called "Default.xaml" in the theme folder, now it only needs one call to import the lib:
`<ResourceDictionary Source="pack://application:,,,/BusyIndicator;component/Theme/Default.xaml" />`