### PR TITLE
fixes #10

### DIFF
--- a/BusyIndicator/Indicator/Indicator.cs
+++ b/BusyIndicator/Indicator/Indicator.cs
@@ -26,8 +26,28 @@ namespace BusyIndicator
 
         public override void OnApplyTemplate()
         {
-            VisualStateManager.GoToElementState((FrameworkElement)GetTemplateChild("MainGrid"), "Active", true);
+            this.UpdateVisualState();
+        }
+
+        protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+
+            if (e.Property == IsVisibleProperty)
+            {
+                this.UpdateVisualState();
+            }
+        }
+
+        private void UpdateVisualState()
+        {
+            if (this.Template == null)
+            {
+                return;
+            }
+
+            var targetState = this.IsVisible ? "Active" : "Inactive";
+            VisualStateManager.GoToElementState((FrameworkElement)GetTemplateChild("MainGrid"), targetState, true);
         }
     }
 }
-

--- a/BusyIndicator/Indicator/Resource/Bar.xaml
+++ b/BusyIndicator/Indicator/Resource/Bar.xaml
@@ -150,6 +150,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Blocks.xaml
+++ b/BusyIndicator/Indicator/Resource/Blocks.xaml
@@ -275,6 +275,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/BouncingDot.xaml
+++ b/BusyIndicator/Indicator/Resource/BouncingDot.xaml
@@ -71,6 +71,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Cogs.xaml
+++ b/BusyIndicator/Indicator/Resource/Cogs.xaml
@@ -83,6 +83,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Cupertino.xaml
+++ b/BusyIndicator/Indicator/Resource/Cupertino.xaml
@@ -400,6 +400,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Dashes.xaml
+++ b/BusyIndicator/Indicator/Resource/Dashes.xaml
@@ -152,6 +152,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/DotCircle.xaml
+++ b/BusyIndicator/Indicator/Resource/DotCircle.xaml
@@ -266,6 +266,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/DoubleBounce.xaml
+++ b/BusyIndicator/Indicator/Resource/DoubleBounce.xaml
@@ -62,6 +62,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Ellipse.xaml
+++ b/BusyIndicator/Indicator/Resource/Ellipse.xaml
@@ -68,6 +68,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Escalade.xaml
+++ b/BusyIndicator/Indicator/Resource/Escalade.xaml
@@ -88,7 +88,7 @@
                                     Value="9"
                                     KeySpline="0.8, 0, 0.2, 1"/>
                             </DoubleAnimationUsingKeyFrames>
-                            
+
                             <DoubleAnimationUsingKeyFrames
                                 Storyboard.TargetName="Path1"
                                 RepeatBehavior="Forever"
@@ -134,6 +134,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/FourDots.xaml
+++ b/BusyIndicator/Indicator/Resource/FourDots.xaml
@@ -107,6 +107,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Grid.xaml
+++ b/BusyIndicator/Indicator/Resource/Grid.xaml
@@ -325,6 +325,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Piston.xaml
+++ b/BusyIndicator/Indicator/Resource/Piston.xaml
@@ -127,6 +127,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Pulse.xaml
+++ b/BusyIndicator/Indicator/Resource/Pulse.xaml
@@ -49,6 +49,7 @@
                                 />
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Ring.xaml
+++ b/BusyIndicator/Indicator/Resource/Ring.xaml
@@ -377,6 +377,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Swirl.xaml
+++ b/BusyIndicator/Indicator/Resource/Swirl.xaml
@@ -61,6 +61,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/ThreeDots.xaml
+++ b/BusyIndicator/Indicator/Resource/ThreeDots.xaml
@@ -110,6 +110,7 @@
                             </DoubleAnimationUsingKeyFrames>
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Twist.xaml
+++ b/BusyIndicator/Indicator/Resource/Twist.xaml
@@ -20,7 +20,7 @@
                         <RotateTransform
 							x:Name="C1" Angle="0"/>
                     </Canvas.RenderTransform>
-                    <Ellipse 
+                    <Ellipse
 						x:Name="E1"
 						Width="10"
 						Height="10"
@@ -73,7 +73,7 @@
                         Fill="{DynamicResource IndicatorForeground}" />
                 </Canvas>
             </Grid>
-            
+
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="ActiveStates">
                     <VisualState x:Name="Active">
@@ -162,6 +162,7 @@
                                 AutoReverse="True" />
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>

--- a/BusyIndicator/Indicator/Resource/Wave.xaml
+++ b/BusyIndicator/Indicator/Resource/Wave.xaml
@@ -166,6 +166,7 @@
                                 />
                         </Storyboard>
                     </VisualState>
+                    <VisualState x:Name="Inactive" />
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
         </Grid>


### PR DESCRIPTION
Introduced new VisualState "Inactive" in all BusyIndicator ControlTemplates and switch to that state if the Indicator is invisible. This stops the animation and reduces CPU and GPU usage.