### PR TITLE
fixed NullReferenceException which may occur after the CPU/GPU fix (#10)

### DIFF
--- a/BusyIndicator/Indicator/Indicator.cs
+++ b/BusyIndicator/Indicator/Indicator.cs
@@ -46,8 +46,14 @@ namespace BusyIndicator
                 return;
             }
 
+            var mainGrid = (FrameworkElement)GetTemplateChild("MainGrid");
+            if (mainGrid == null)
+            {
+                return;
+            }
+
             var targetState = this.IsVisible ? "Active" : "Inactive";
-            VisualStateManager.GoToElementState((FrameworkElement)GetTemplateChild("MainGrid"), targetState, true);
+            VisualStateManager.GoToElementState(mainGrid, targetState, true);
         }
     }
 }


### PR DESCRIPTION
I am sorry. My recent changes introduced a `NullReferenceException` in certain scenarios when the `MainGrid` element could not yet be retrieved from the template. This issue does not occur in the Demo application, but in my local application.

I have simply added a null check to fix this.