### PR TITLE
`BusyMask`: respect the initial value of `IsBusy`, deprecate `IsBusyAtStartup`

### DIFF
--- a/BusyIndicator/BusyMask/BusyMask.cs
+++ b/BusyIndicator/BusyMask/BusyMask.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -24,6 +25,7 @@ namespace BusyIndicator
 
         [Description("Gets or sets whether the indicator is busy by default on startup.")]
         private bool _IsBusyATStartup;
+        [Obsolete("Use the initial value of IsBusy to control the initial state.")]
         public bool IsBusyAtStartup
         {
             get { return _IsBusyATStartup; }
@@ -116,8 +118,7 @@ namespace BusyIndicator
 
         public override void OnApplyTemplate()
         {
-            if (IsBusyAtStartup) IsBusy = true;
-            ChangeVisualState(IsBusyAtStartup);
+            ChangeVisualState(IsBusyAtStartup || IsBusy);
         }
 
         protected virtual void ChangeVisualState(bool isBusyContentVisible = false)

--- a/Demo/MainWindow.xaml.cs
+++ b/Demo/MainWindow.xaml.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading.Tasks;
-using System.Windows;
-using System.Text.RegularExpressions;
-using System.Windows.Input;
+﻿using System;
 using System.ComponentModel;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Input;
 
 namespace Demo
 {
@@ -17,6 +18,9 @@ namespace Demo
             
             if(BusyIndicator.IsBusyAtStartup)
                 Stop();
+
+            // Emulate that IsBusy is true from the very beginning:
+            Button_Click(null, null);
         }
 
         public bool IsBusy
@@ -36,7 +40,7 @@ namespace Demo
 
         private async void Stop()
         {
-            await Task.Delay(System.TimeSpan.FromSeconds(3));
+            await Task.Delay(TimeSpan.FromSeconds(3));
             IsBusy = false;
         }
 
@@ -59,7 +63,7 @@ namespace Demo
             }
 
             IsBusy = true;
-            await Task.Delay(System.TimeSpan.FromSeconds(duration));
+            await Task.Delay(TimeSpan.FromSeconds(duration));
             IsBusy = false;
         }
     }


### PR DESCRIPTION
Closes #24.

We can outright remove `IsBusyAtStartup` now, but so far I chose to keep it (to not break compilation is users' projects) and respect its initial value (so the change is not breaking for people who set it to `True`).

I have added a snippet to the demo app to test the change.